### PR TITLE
Lambda that deletes old lambda versions on a schedule

### DIFF
--- a/delete_old_lambda_versions.py
+++ b/delete_old_lambda_versions.py
@@ -1,0 +1,17 @@
+import boto3
+
+client = boto3.client('lambda', region_name='eu-west-1')
+
+functions_paginator = client.get_paginator('list_functions')
+version_paginator = client.get_paginator('list_versions_by_function')
+
+for function_page in functions_paginator.paginate():
+    for function in function_page['Functions']:
+        aliases = client.list_aliases(FunctionName=function['FunctionArn'])
+        alias_versions = [alias['FunctionVersion'] for alias in aliases['Aliases']]
+        for version_page in version_paginator.paginate(FunctionName=function['FunctionArn']):
+            for version in version_page['Versions']:
+                arn = version['FunctionArn']
+                if version['Version'] != function['Version'] and version['Version'] not in alias_versions:
+                    print('  🥊 {}'.format(arn))
+                    client.delete_function(FunctionName=arn)

--- a/delete_old_lambda_versions.py
+++ b/delete_old_lambda_versions.py
@@ -2,16 +2,18 @@ import boto3
 
 client = boto3.client('lambda', region_name='eu-west-1')
 
-functions_paginator = client.get_paginator('list_functions')
-version_paginator = client.get_paginator('list_versions_by_function')
 
-for function_page in functions_paginator.paginate():
-    for function in function_page['Functions']:
-        aliases = client.list_aliases(FunctionName=function['FunctionArn'])
-        alias_versions = [alias['FunctionVersion'] for alias in aliases['Aliases']]
-        for version_page in version_paginator.paginate(FunctionName=function['FunctionArn']):
-            for version in version_page['Versions']:
-                arn = version['FunctionArn']
-                if version['Version'] != function['Version'] and version['Version'] not in alias_versions:
-                    print('  🥊 {}'.format(arn))
-                    client.delete_function(FunctionName=arn)
+def lambda_handler(event, context):
+    functions_paginator = client.get_paginator('list_functions')
+    version_paginator = client.get_paginator('list_versions_by_function')
+
+    for function_page in functions_paginator.paginate():
+        for function in function_page['Functions']:
+            aliases = client.list_aliases(FunctionName=function['FunctionArn'])
+            alias_versions = [alias['FunctionVersion'] for alias in aliases['Aliases']]
+            for version_page in version_paginator.paginate(FunctionName=function['FunctionArn']):
+                for version in version_page['Versions']:
+                    arn = version['FunctionArn']
+                    if version['Version'] != function['Version'] and version['Version'] not in alias_versions:
+                        print('  🥊 {}'.format(arn))
+                        client.delete_function(FunctionName=arn)

--- a/template.yaml
+++ b/template.yaml
@@ -667,7 +667,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                  - lambda.ListFunctions
+                  - lambda:ListFunctions
                   - lambda:ListVersionsByFunction
                   - lambda:DeleteFunction
                 Resource: "*"

--- a/template.yaml
+++ b/template.yaml
@@ -667,6 +667,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
+                  - lambda:ListAliases
                   - lambda:ListFunctions
                   - lambda:ListVersionsByFunction
                   - lambda:DeleteFunction

--- a/template.yaml
+++ b/template.yaml
@@ -628,10 +628,10 @@ Resources:
       LogGroupName: !Sub '/aws/lambda/${LambdaVersionCleanupFunction}'
       RetentionInDays: 90
 
-  # Lambda function to delete old versions
   LambdaVersionCleanupFunction:
     Type: AWS::Serverless::Function
     Properties:
+      Description: 'Lambda function to delete old version of all lambda functions'
       Handler: delete_old_lambda_versions.lambda_handler
       Runtime: python3.11
       Timeout: 900
@@ -639,17 +639,17 @@ Resources:
       Role: !GetAtt LambdaVersionCleanupRole.Arn
       CodeUri: .
       Events:
-          # Optional: Schedule to trigger the Lambda function
           ScheduledEvent:
             Type: Schedule
             Properties:
-              Schedule: rate(7 days)  # Run every 7 days
+              Description: 'Schedule to trigger deletion of old versions of lambda functions'
+              Schedule: rate(7 days)
               Name: CleanupLambdaVersionSchedule
 
-  # IAM Role for the Lambda function
   LambdaVersionCleanupRole:
     Type: AWS::IAM::Role
     Properties:
+      Description: 'IAM role for the lamda that deletes old versions of all lambda functions'
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/template.yaml
+++ b/template.yaml
@@ -622,6 +622,12 @@ Resources:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
 
+  LambdaVersionCleanupFunctionAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${LambdaVersionCleanupFunction}'
+      RetentionInDays: 90
+
   # Lambda function to delete old versions
   LambdaVersionCleanupFunction:
     Type: AWS::Serverless::Function

--- a/template.yaml
+++ b/template.yaml
@@ -634,7 +634,7 @@ Resources:
     Properties:
       Handler: delete_old_lambda_versions.lambda_handler
       Runtime: python3.11
-      Timeout: 60
+      Timeout: 900
       MemorySize: 128
       Role: !GetAtt LambdaVersionCleanupRole.Arn
       CodeUri: .

--- a/template.yaml
+++ b/template.yaml
@@ -627,7 +627,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: delete_old_lambda_versions.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.11
       Timeout: 60
       MemorySize: 128
       Role: !GetAtt LambdaVersionCleanupRole.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -667,6 +667,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
+                  - lambda.ListFunctions
                   - lambda:ListVersionsByFunction
                   - lambda:DeleteFunction
                 Resource: "*"

--- a/template.yaml
+++ b/template.yaml
@@ -66,8 +66,8 @@ Parameters:
 
 Conditions:
   WithSuffix: !Not [ !Equals [ !Ref Suffix, '' ] ]
-  CreateBackups: 
-    Fn::Equals: 
+  CreateBackups:
+    Fn::Equals:
       - !Ref UseBackup
       - 'true'
 
@@ -621,3 +621,51 @@ Resources:
       ManagedPolicyArns:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
+
+  # Lambda function to delete old versions
+  LambdaVersionCleanupFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: delete_old_lambda_versions.lambda_handler
+      Runtime: python3.9
+      Timeout: 60
+      MemorySize: 128
+      Role: !GetAtt LambdaVersionCleanupRole.Arn
+      CodeUri: .
+      Events:
+          # Optional: Schedule to trigger the Lambda function
+          ScheduledEvent:
+            Type: Schedule
+            Properties:
+              Schedule: rate(7 days)  # Run every 7 days
+              Name: CleanupLambdaVersionSchedule
+
+  # IAM Role for the Lambda function
+  LambdaVersionCleanupRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaVersionCleanupPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - lambda:ListVersionsByFunction
+                  - lambda:DeleteFunction
+                Resource: "*"
+
+Outputs:
+  LambdaVersionCleanupFunction:
+    Description: "ARN of the version cleanup Lambda function"
+    Value: !GetAtt LambdaVersionCleanupFunction.Arn


### PR DESCRIPTION
Added a python function that removes old versions of functions weekly. When we enable snapstart on more functions, this is much more convenient that running it manually. 