### PR TITLE
fix: Disable PITR for weekly/quarterly backups

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -621,7 +621,7 @@ Resources:
             ScheduleExpression: 'cron(0 12 ? * 1 *)' # Every Sunday at 12:00
             StartWindowMinutes: 60
             CompletionWindowMinutes: 120
-            EnableContinuousBackup: true
+            EnableContinuousBackup: false # PITR limits retention to 35 days
             Lifecycle:
               DeleteAfterDays: !Ref DaysToRetainWeeklyBackup
             RecoveryPointTags:
@@ -636,7 +636,7 @@ Resources:
             ScheduleExpression: 'cron(0 0 1 1,4,7,10 ? *)' # At start of every quarter
             StartWindowMinutes: 60
             CompletionWindowMinutes: 120
-            EnableContinuousBackup: true
+            EnableContinuousBackup: false # PITR limits retention to 35 days
             Lifecycle:
               DeleteAfterDays: !Ref DaysToRetainQuarterlyBackup
             RecoveryPointTags:


### PR DESCRIPTION
Hopefully fixes conflict between incremental backup and retention period. With incremental backups enabled, no backups in the plan can have a retention period greater than 35 days (which only applies to test/prod environments).