### PR TITLE
Add dualstack

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -305,6 +305,7 @@ Resources:
       EndpointConfiguration:
         Types:
           - !Ref ApiGatewayEndpointType
+        IpAddressType: 'dualstack'
 
   CristinImportNviQueue:
     Type: AWS::SQS::Queue


### PR DESCRIPTION
- Adds dualstack to the custom domain…this has some consequences:
  - APIs using policies restricted to IP-ranges require updating
  - Lambda authorizers need updating