### PR TITLE
fix: Add DLQ for CristinImportNviQueue

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -309,8 +309,8 @@ Resources:
   CristinImportNviQueue:
     Type: AWS::SQS::Queue
     Properties:
-      VisibilityTimeoutSeconds: 300  # 5 minutes
-      MessageRetentionPeriod: 1209600  # 14 days
+      VisibilityTimeout: 300 # 5 minutes
+      MessageRetentionPeriod: 1209600 # 14 days
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt CristinImportNviQueueDLQ.Arn
         maxReceiveCount: 3
@@ -318,7 +318,27 @@ Resources:
   CristinImportNviQueueDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      MessageRetentionPeriod: 1209600  # 14 days
+      MessageRetentionPeriod: 1209600 # 14 days
+
+  CristinImportNviQueueDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: NVI - Processing Cristin import event failed
+      AlarmDescription: >
+        Check messages on CristinImportNviQueueDLQ. This indicates that 
+        `nva-nvi` has failed to process imported Cristin results.
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Statistic: Sum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt CristinImportNviQueueDLQ.QueueName
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref SlackSNSTopic
 
   VPC:
     Type: AWS::EC2::VPC

--- a/template.yaml
+++ b/template.yaml
@@ -308,6 +308,17 @@ Resources:
 
   CristinImportNviQueue:
     Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeoutSeconds: 300  # 5 minutes
+      MessageRetentionPeriod: 1209600  # 14 days
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt CristinImportNviQueueDLQ.Arn
+        maxReceiveCount: 3
+
+  CristinImportNviQueueDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600  # 14 days
 
   VPC:
     Type: AWS::EC2::VPC


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49439

This adds a DLQ configuration to the `CristinImportNviQueue` in order to stop the infinite loop when `nva-nvi` fails to process messages.