### PR TITLE
ci: Update workflow

### DIFF
--- a/.github/workflows/cfn-linter.yaml
+++ b/.github/workflows/cfn-linter.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup CloudFormation Linter
-      uses: scottbrenner/cfn-lint-action@v2
+      uses: scottbrenner/cfn-lint-action@9636da81fb2e0cef75725d8dda11b0148940b7ae #v2.6.0
     - name: Print the Cloud Formation Linter Version & run Linter.
       run: |
         cfn-lint --version

--- a/.github/workflows/cfn-linter.yaml
+++ b/.github/workflows/cfn-linter.yaml
@@ -1,6 +1,14 @@
 name: Lint CloudFormation Templates
+permissions:
+  contents: write # To submit dependency graph
+  checks: write # To publish test results
+  pull-requests: write # To comment on PRs
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   cloudformation-linter:
@@ -10,12 +18,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
-    - name: cfn-lint
-      uses: scottbrenner/cfn-lint-action@main
-      with:
-        entrypoint: /bin/sh
-        args: "-c \"cat template.yaml | sed '/CODEBUILD_RESOLVED_SOURCE_VERSION/d' | cfn-lint -\""
+    - name: Setup CloudFormation Linter
+      uses: scottbrenner/cfn-lint-action@v2
+    - name: Print the Cloud Formation Linter Version & run Linter.
+      run: |
+        cfn-lint --version
+        cfn-lint -t ./template.yaml
 
     - name: Cloud formation security checks
       uses: stelligent/cfn_nag@master

--- a/.github/workflows/cfn-linter.yaml
+++ b/.github/workflows/cfn-linter.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup CloudFormation Linter
       uses: scottbrenner/cfn-lint-action@9636da81fb2e0cef75725d8dda11b0148940b7ae #v2.6.0
     - name: Print the Cloud Formation Linter Version & run Linter.

--- a/template.yaml
+++ b/template.yaml
@@ -156,12 +156,21 @@ Resources:
 
   EventsBucket:
     Type: AWS::S3::Bucket
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       BucketName: !If
         - WithSuffix
         - !Sub 'eventbridge-event-bodies-${AWS::AccountId}-${Suffix}'
         - !Sub 'eventbridge-event-bodies-${AWS::AccountId}'
+      # FIXME: Remove AccessControl and OwnershipControls in follow-up PR
       AccessControl: Private
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       LifecycleConfiguration:
         Rules:
           - Id: "ExpiryPolicy"
@@ -169,6 +178,23 @@ Resources:
             Status: Enabled
       VersioningConfiguration:
         Status: Suspended
+
+  EventsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref EventsBucket
+      PolicyDocument:
+        Statement:
+          - Sid: DenyPublicAccess
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub 'arn:aws:s3:::${EventsBucket}'
+              - !Sub 'arn:aws:s3:::${EventsBucket}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
 
   ChatbotRole:
     Type: "AWS::IAM::Role"
@@ -239,6 +265,11 @@ Resources:
   # the NVA Resources service stack should not necessarily break the NVA search service
   ExpandedResourcesBucket:
     Type: AWS::S3::Bucket
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       BucketName: !If
         - WithSuffix
@@ -249,28 +280,77 @@ Resources:
           "EventBridgeEnabled": true
         }
       }
+      # FIXME: Remove AccessControl and OwnershipControls in follow-up PR
       AccessControl: Private
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       VersioningConfiguration:
         Status: Suspended
+
+  ExpandedResourcesBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ExpandedResourcesBucket
+      PolicyDocument:
+        Statement:
+          - Sid: DenyPublicAccess
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub 'arn:aws:s3:::${ExpandedResourcesBucket}'
+              - !Sub 'arn:aws:s3:::${ExpandedResourcesBucket}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
 
   # Bucket for storing API responses that are too large to pass through Lambda
   LargeApiResponsesBucket:
     Type: AWS::S3::Bucket
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       BucketName: !If
         - WithSuffix
         - !Sub 'large-api-responses-${AWS::AccountId}-${Suffix}'
         - !Sub 'large-api-responses-${AWS::AccountId}'
+      # FIXME: Remove AccessControl and OwnershipControls in follow-up PR
       AccessControl: Private
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       LifecycleConfiguration:
         Rules:
           - Status: Enabled
             ExpirationInDays: 1
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+
+  LargeApiResponsesBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LargeApiResponsesBucket
+      PolicyDocument:
+        Statement:
+          - Sid: DenyPublicAccess
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub 'arn:aws:s3:::${LargeApiResponsesBucket}'
+              - !Sub 'arn:aws:s3:::${LargeApiResponsesBucket}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
 
   ResourceStorageBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If
         - WithSuffix
@@ -321,11 +401,38 @@ Resources:
   NvaAthenaQueriesBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       BucketName: !Sub 'nva-athena-queries-${AWS::AccountId}'
+      # FIXME: Remove AccessControl and OwnershipControls in follow-up PR
       AccessControl: Private
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       VersioningConfiguration:
         Status: Suspended
+
+  NvaAthenaQueriesBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref NvaAthenaQueriesBucket
+      PolicyDocument:
+        Statement:
+          - Sid: DenyPublicAccess
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub 'arn:aws:s3:::${NvaAthenaQueriesBucket}'
+              - !Sub 'arn:aws:s3:::${NvaAthenaQueriesBucket}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
 
   BackendDomainName:
     Type: AWS::ApiGateway::DomainName


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-50416

Updates the workflow with relevant sections from the [shared workflow](https://github.com/BIBSYSDEV/nva-github-workflows). Because the shared workflow is designed for Java projects, we cannot reference it directly here.

Because the CloudFormation linter now actually works, we are also fixing the linter errors:

- Adds `UpdateReplacePolicy: Retain` to S3 buckets
- Adds new BucketPolicy enforcing HTTPS (deny `s3:*` when `aws:SecureTransport: false`)
- Temporarily suppresses linter warning `W3045` because we cannot fix it in this PR. We need to first enable ACLs to allow us to remove the deprecated config, then reset ACLs in a subsequent PR.