### PR TITLE
fix: Prevent automated deletion of resources

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -156,6 +156,8 @@ Resources:
 
   EventsBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If
         - WithSuffix
@@ -209,6 +211,8 @@ Resources:
 
   SlackSNSTopic:
     Type: AWS::SNS::Topic
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
 
   SlackSNSTopicPolicy:
     Type: AWS::SNS::TopicPolicy
@@ -258,6 +262,8 @@ Resources:
   # the NVA Resources service stack should not necessarily break the NVA search service
   ExpandedResourcesBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If
         - WithSuffix
@@ -490,6 +496,8 @@ Resources:
 
   NatGatewayEIP:
     Type: AWS::EC2::EIP
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     DependsOn: InternetGatewayAttachment
     Properties:
       Domain: vpc
@@ -893,6 +901,8 @@ Resources:
 
   NvaBackupVault:
     Type: AWS::Backup::BackupVault
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BackupVaultName: NvaBackupVault
       AccessPolicy:


### PR DESCRIPTION
Prevents important resources from being deleted automatically (e.g. if stack deleted or resource modified). See https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-deletionpolicy.html for details.